### PR TITLE
Bug fix on UI to CoffeeEdit form value power accessible

### DIFF
--- a/client/src/CoffeeShopEdit.js
+++ b/client/src/CoffeeShopEdit.js
@@ -98,7 +98,7 @@ class CoffeeShopEdit extends Component {
               <FormGroup className="col-md-4 mb-3">
                 <Label for="powerAccessible">Power Accessible?</Label>
                 <Input type="select" name="powerAccessible" id="powerAccessible"
-                       value={item.powerAccessible ? 'true' : 'false'}
+                       value={item.powerAccessible === 'true' ? 'true' : 'false'}
                        onChange={this.handleChange}>
                   <option value="true">Yes</option>
                   <option value="false">No</option>


### PR DESCRIPTION
The power accessible attribute is being treated as a boolean when it is a string. The UI will then display "Yes" when powerAccessible is set to a value and "No" when it is empty